### PR TITLE
Add missing XML symbol in acl.xml

### DIFF
--- a/etc/adminhtml/acl.xml
+++ b/etc/adminhtml/acl.xml
@@ -13,4 +13,4 @@
             </resource>
         </resources>
     </acl>
-</config
+</config>


### PR DESCRIPTION
ACL permissions currently don't work due to a missing symbol at the end of acl.xml.