### PR TITLE
Move object instantiation to dependency injection

### DIFF
--- a/Controller/Adminhtml/Admin/Index.php
+++ b/Controller/Adminhtml/Admin/Index.php
@@ -1,7 +1,6 @@
 <?php
 namespace Queueit\KnownUser\Controller\Adminhtml\Admin;
 
-require_once(__DIR__ . '../../../../IntegrationInfoProvider.php');
 use \DateTime;
 
 class Index extends \Magento\Backend\App\Action
@@ -12,18 +11,26 @@ class Index extends \Magento\Backend\App\Action
     protected $resultPageFactory;
 
     /**
+     * @var \Queueit\KnownUser\IntegrationInfoProvider
+     */
+    protected $configProvider;
+
+    /**
      * Constructor
      *
      * @param \Magento\Backend\App\Action\Context $context
      * @param \Magento\Framework\View\Result\PageFactory $resultPageFactory
+     * @param \Queueit\KnownUser\IntegrationInfoProvider $configProvider
      */
     public function __construct(
         \Magento\Backend\App\Action\Context $context,
-        \Magento\Framework\View\Result\PageFactory $resultPageFactory
+        \Magento\Framework\View\Result\PageFactory $resultPageFactory,
+        \Queueit\KnownUser\IntegrationInfoProvider $configProvider
     ) {
 
         parent::__construct($context);
         $this->resultPageFactory = $resultPageFactory;
+        $this->configProvider = $configProvider;
     }
 
     /**
@@ -33,8 +40,7 @@ class Index extends \Magento\Backend\App\Action
      */
     public function execute()
     {
-        $configProvider = new \Queueit\KnownUser\IntegrationInfoProvider();
-        $configText =  $configProvider->getIntegrationInfo(false);
+        $configText =  $this->configProvider->getIntegrationInfo(false);
         $customerIntegration = json_decode($configText, true);
         $resultPage = $this->resultPageFactory->create();
         $layout = $resultPage->getLayout();

--- a/Controller/Adminhtml/Admin/UploadConfig.php
+++ b/Controller/Adminhtml/Admin/UploadConfig.php
@@ -4,10 +4,23 @@ namespace Queueit\KnownUser\Controller\Adminhtml\Admin;
 
 class UploadConfig extends \Magento\Framework\App\Action\Action
 {
+    /**
+     * @var \Queueit\KnownUser\IntegrationInfoProvider
+     */
+    protected $configProvider;
 
-	public function execute()
+    /**
+     * Constructor
+     *
+     * @param \Queueit\KnownUser\IntegrationInfoProvider $configProvider
+     */
+    public function __construct(\Queueit\KnownUser\IntegrationInfoProvider $configProvider) {
+        $this->configProvider = $configProvider;
+    }
+
+    public function execute()
 	{
-		$configProvider = new \Queueit\KnownUser\IntegrationInfoProvider();
+		$configProvider = $this->configProvider;
 		if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 			print_r('{');
 			if (isset($_FILES['files'])) {

--- a/IntegrationInfoProvider.php
+++ b/IntegrationInfoProvider.php
@@ -1,6 +1,5 @@
 <?php
 namespace Queueit\KnownUser;
-require_once( __DIR__ .'/IntegrationInfoProviderInterface.php');
         /**
      * Update IntegraionInfo.
      *@api
@@ -10,11 +9,34 @@ class IntegrationInfoProvider implements IntegrationInfoProviderInterface
 const CACHE_KEY = "_queueit_integrationinfo";
 const CONFIG_SECRETKEY = 'queueit_knownuser/configuration/secretkey';
 
+    /**
+     * @var \Magento\Framework\App\CacheInterface
+     */
+    protected $cache;
+
+    /**
+     * @var \Magento\Framework\App\ResourceConnection
+     */
+    protected $resourceConnection;
+
+    /**
+     * @var \Magento\Framework\App\Config\ScopeConfigInterface
+     */
+    protected $scopeConfig;
+
+    public function __construct(
+        \Magento\Framework\App\CacheInterface $cache,
+        \Magento\Framework\App\ResourceConnection $resourceConnection,
+        \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
+    ) {
+        $this->cache = $cache;
+        $this->resourceConnection = $resourceConnection;
+        $this->scopeConfig = $scopeConfig;
+    }
 
    public function getIntegrationInfo($useCache)
    {
-    $om = \Magento\Framework\App\ObjectManager::getInstance();
-    $cacheInterface = $om->get('Magento\Framework\App\CacheInterface');
+    $cacheInterface = $this->cache;
     $integrationConfig = $cacheInterface->load(self::CACHE_KEY);
      if($integrationConfig && $useCache)
      {
@@ -22,8 +44,7 @@ const CONFIG_SECRETKEY = 'queueit_knownuser/configuration/secretkey';
      }
      else
      {
-        $objectManager = \Magento\Framework\App\ObjectManager::getInstance(); // Instance of object manager
-        $resource = $objectManager->get('Magento\Framework\App\ResourceConnection');
+        $resource = $this->resourceConnection;
         $connection = $resource->getConnection();
         $tableName = $resource->getTableName('queueit_integrationinfo'); //gives table name with prefix
         
@@ -51,8 +72,7 @@ const CONFIG_SECRETKEY = 'queueit_knownuser/configuration/secretkey';
    {
         if($this->isValidRequest($integrationInfo,$hash))
         {
-            $objectManager = \Magento\Framework\App\ObjectManager::getInstance();
-            $resource = $objectManager->get('Magento\Framework\App\ResourceConnection');
+            $resource = $this->resourceConnection;
             $connection = $resource->getConnection();
             $tableName = $resource->getTableName('queueit_integrationinfo'); //gives table name with prefix
             //Insert Data into table
@@ -68,8 +88,7 @@ const CONFIG_SECRETKEY = 'queueit_knownuser/configuration/secretkey';
 
    private function isValidRequest($integrationInfo,$hash)
    {
-      $om = \Magento\Framework\App\ObjectManager::getInstance();
-      $scopeConfig = $om->get('\Magento\Framework\App\Config\ScopeConfigInterface');
+      $scopeConfig = $this->scopeConfig;
       $secretKey = $scopeConfig->getValue(
           self::CONFIG_SECRETKEY,
           \Magento\Store\Model\ScopeInterface::SCOPE_STORE

--- a/KnownUserHandler.php
+++ b/KnownUserHandler.php
@@ -1,7 +1,6 @@
 <?php
 namespace Queueit\KnownUser;
 
-require_once( __DIR__ .'/IntegrationInfoProvider.php');
 require_once( __DIR__ .'/../knownuserv3/Models.php');
 require_once( __DIR__ .'/../knownuserv3/KnownUser.php');
 
@@ -9,6 +8,16 @@ require_once( __DIR__ .'/../knownuserv3/KnownUser.php');
 class KnownUserHandler
 {
 	const MAGENTO_SDK_VERSION = "1.3.0";
+
+    /**
+     * @var Psr\Log\LoggerInterface
+     */
+    protected $logger;
+
+    public function __construct(Psr\Log\LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+    }
 
     public function handleRequest($customerId, $secretKey,  $observer)
     {
@@ -60,8 +69,7 @@ class KnownUserHandler
         }
         catch(\Exception $e)
         {
-                $objectManager = \Magento\Framework\App\ObjectManager::getInstance(); // Instance of object manager
-                $logger = $objectManager->get("Psr\Log\LoggerInterface");
+                $logger = $this->logger;
                 $logger->debug("Queueit-knownUser: Exception while validation user request". $e);
           //log the exception
         }

--- a/Observer/KnownUserObserver.php
+++ b/Observer/KnownUserObserver.php
@@ -1,6 +1,5 @@
 <?php
 namespace Queueit\KnownUser\Observer;
-require_once( __DIR__ .'/../IntegrationInfoProvider.php');
 use Magento\Framework\Event\ObserverInterface;
 
 
@@ -12,16 +11,20 @@ class KnownUserObserver implements ObserverInterface
   private $scopeConfig;
   private $helper;
   private $state;
+  private $knownUserHandler;
+
   const CONFIG_ENABLED = 'queueit_knownuser/configuration/enable';
   const CONFIG_SECRETKEY = 'queueit_knownuser/configuration/secretkey';
   const CONFIG_CUSTOMERID = 'queueit_knownuser/configuration/customerid';
-  public function __construct(
-  \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
-  \Magento\Framework\App\State $state)
-  {
-  $this->scopeConfig = $scopeConfig;
-    $this->state= $state;
 
+  public function __construct(
+    \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
+    \Magento\Framework\App\State $state,
+    \Queueit\KnownUser\KnownUserHandler $knownUserHandler
+  ) {
+    $this->scopeConfig = $scopeConfig;
+    $this->state= $state;
+    $this->knownUserHandler = $knownUserHandler;
   }
 
   public function execute(\Magento\Framework\Event\Observer $observer)
@@ -54,8 +57,7 @@ class KnownUserObserver implements ObserverInterface
       if($enable)
       {
         //if module is enable and request is not ajax do queue logic
-            $knownUserHandler = new \Queueit\KnownUser\KnownUserHandler();
-            $knownUserHandler->handleRequest($customerId,$secretKey, $observer);
+            $this->knownUserHandler->handleRequest($customerId,$secretKey, $observer);
 	 }
 	 return $this;
   }


### PR DESCRIPTION
Instead of instantiating objects directly in the methods, we should let Magento create them automatically via dependency injection.

I haven't been able to test this locally yet, so should definitely test everything first.